### PR TITLE
Add theoretical context to READMEs

### DIFF
--- a/01_basic_operations/README.md
+++ b/01_basic_operations/README.md
@@ -44,6 +44,10 @@ imsave('output.jpg', image, quality=50)  # qualité réduite
 - Analyse d'image élémentaire
 - Conversion et optimisation de formats
 
+## Contexte theorique
+
+Une image numerique se definit comme une fonction discrete decrite par une matrice de valeurs. Les operations elementaires manipulent ces valeurs en modifiant l'espace de couleur ou leur distribution. Les conversions de format et la compression utilisent cette representation pour reduire la taille des fichiers tout en preservant l'information visuelle.
+
 ## Ressources utiles
 
 - [Documentation scikit-image](https://scikit-image.org/docs/stable/)

--- a/02_spatial_filtering/README.md
+++ b/02_spatial_filtering/README.md
@@ -9,6 +9,8 @@ La convolution consiste à combiner l'image avec un noyau pour produire un résu
 ```
 g(x,y) = \sum_i \sum_j f(i,j)\,h(x-i, y-j)
 ```
+Cette operation correspond a une integration discrete ou chaque coefficient du noyau pondere l'intensite des pixels voisins. La conception des filtres (moyenne, gaussien, Laplacien...) provient de la theorie du traitement du signal et permet de selectionner ou de supprimer certaines composantes frequentielles.
+
 
 - `f` : image d'entrée
 - `h` : noyau

--- a/03_fourier_analysis/README.md
+++ b/03_fourier_analysis/README.md
@@ -7,6 +7,8 @@ Ce module traite l'image dans le domaine fréquentiel grâce à la transformée 
 - **Transformée de Fourier** : décompose l'image en composantes de fréquences.
 - **Domaine fréquentiel** : représentation en fréquence plutôt qu'en pixels.
 - **Amplitude et phase** : informations essentielles de la TFD.
+La TFD transforme la fonction image en somme de sinusoides de differentes frequences. Les hautes frequences traduisent des variations rapides tandis que les basses frequences decrivent les structures globales. Manipuler ce spectre permet de filtrer ou de compresser l'information plus efficacement que dans le domaine spatial.
+
 
 ## Scripts
 

--- a/04_image_segmentation/README.md
+++ b/04_image_segmentation/README.md
@@ -9,6 +9,8 @@ La segmentation découpe une image en régions cohérentes pour en faciliter l'a
 - **Clustering** : regroupement de pixels similaires (ex. K-means).
 - **Croissance de région** : expansion à partir de points de départ.
 - **Watershed** : approche basée sur la topographie.
+La segmentation traduit generalement une modelisation de l'image par regions homogenes selon l'intensite, la texture ou la forme. Elle utilise des approches deterministes comme le seuillage, ainsi que des methodes statistiques ou d'optimisation pour regrouper les pixels partageant des caracteristiques communes.
+
 
 ## Fichiers principaux
 

--- a/05_histogram_enhancement/README.md
+++ b/05_histogram_enhancement/README.md
@@ -7,6 +7,8 @@ Ce dossier présente plusieurs transformations d'intensité : correction gamma, 
 - **LUT (Look-Up Table)** : transformation pixel par pixel.
 - **Égalisation d'histogramme** : redistribution des niveaux de gris pour augmenter le contraste.
 - **Matching d'histogramme** : adaptation à l'histogramme d'une image de référence.
+Ces techniques modifient la distribution des niveaux de gris afin d'etendre la dynamique de l'image. L'egalisation s'appuie sur la theorie des probabilites pour uniformiser l'histogramme, tandis que le matching transfere la distribution d'une image de reference vers celle traitee.
+
 
 ## Scripts
 

--- a/06_image_restoration/README.md
+++ b/06_image_restoration/README.md
@@ -9,6 +9,8 @@ Une image dégradée peut s'écrire :
 g = h * f + n
 ```
 avec `h` la fonction d'étalement (PSF) et `n` le bruit ajouté.
+Ce modele provient de la theorie des systemes lineaires ou l'acquisition est assimilee a la convolution de l'image originale par une PSF. La restauration tente d'inverser ce processus en tenant compte du bruit pour retrouver l'image la plus proche possible de la verite terrain.
+
 
 ## Méthodes de restauration
 

--- a/07_image_registration/README.md
+++ b/07_image_registration/README.md
@@ -6,6 +6,8 @@ Ce TP met en œuvre l'algorithme ICP (Iterative Closest Point) ainsi qu'une sél
 
 On cherche la rotation `R` et la translation `t` qui minimisent la distance quadratique entre les points correspondants :
 \[ C(R,t) = \sum_i \| q_i - (R p_i + t) \|^2 \]
+L'alignement d'images est un probleme d'optimisation non lineaire ou l'on cherche la transformation geometrique qui superpose au mieux deux ensembles de points ou d'intensites. L'algorithme ICP procède par estimations successives des correspondances et de la transformation jusqu'a convergence.
+
 
 ## Scripts
 

--- a/08_noise_and_filtering/README.md
+++ b/08_noise_and_filtering/README.md
@@ -8,6 +8,8 @@ Types de bruit :
 3. **Poivre et sel** : pixels noirs ou blancs aléatoires.
 4. **Exponentiel** : modélise certains phénomènes de décroissance.
 
+La generation de bruit suit des distributions de probabilite definies afin de simuler les perturbations observees lors de l'acquisition. Comprendre ces modeles permet d'evaluer la robustesse des filtres en presence de degradations controlees.
+
 ## Script
 
 - `random_noise.py` : création et visualisation des bruits précédents.

--- a/09_medical_segmentation/README.md
+++ b/09_medical_segmentation/README.md
@@ -13,6 +13,8 @@ Combinaison de seuillage et de morphologie mathématique :
 - Dilatation binaire pour isoler la thèque.
 - Recherche de zones sombres pour la vascularisation.
 - Calcul des surfaces et proportions des différentes régions.
+La segmentation medicale repose sur une modelisation anatomique et sur des operateurs morphologiques destines a isoler des structures coherentes. Ces traitements exploitent la connaissance des intensites propres aux tissus pour guider le seuillage et le post-traitement des regions obtenues.
+
 
 ## Fichiers
 

--- a/10_shape_classification/README.md
+++ b/10_shape_classification/README.md
@@ -8,6 +8,8 @@ Ce TP illustre l'utilisation de techniques d'apprentissage automatique pour reco
 2. **Prétraitement** : normalisation des données et séparation entraînement/test.
 3. **Algorithmes** : SVM à noyau RBF, perceptron multicouche, forêts aléatoires et K plus proches voisins.
 4. **Évaluation** : matrice de confusion et taux de réussite pour comparer les méthodes.
+La reconnaissance de formes repose sur l'extraction de descripteurs invariants caracterisant la geometrie des objets. Ces vecteurs servent ensuite a entrainer des classifieurs supervises fondees sur la theorie statistique de la decision.
+
 
 Les scripts fournissent également des visualisations et un classement des caractéristiques les plus discriminantes.
 

--- a/11_multiscale_analysis/README.md
+++ b/11_multiscale_analysis/README.md
@@ -2,6 +2,8 @@
 
 Ce module présente la décomposition pyramidale (gaussienne et laplacienne) ainsi que des approches morphologiques pour analyser les images à plusieurs résolutions.
 
+L'analyse multi-echelle s'inspire de la theorie des ondelettes et de la morphologie mathematique pour representer les images a plusieurs niveaux de details. Les pyramides gaussiennes et laplaciennes offrent des approximations successives facilitant la detection de structures selon leur taille.
+
 ## Contenu
 
 - `pyramidal_decomposition.py` : construction et reconstruction de pyramides.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Projet de Traitement d'Images
 
 Ce dépôt regroupe une série de scripts Python couvrant de nombreuses thématiques du traitement d'images. Chaque dossier `TPx` correspond à un thème de travaux pratiques.
+## Bases theoriques
+
+Le traitement d'images s'appuie sur la representation matricielle des pixels. Les filtrages spatiaux manipulent cette matrice via la convolution avec un noyau. L'analyse de Fourier permet de travailler dans le domaine frequentiel pour isoler les basses et hautes frequences. La segmentation repose sur des criteres d'intensite ou de texture pour regrouper les pixels en regions homogenes. Enfin la restauration modele la degradation comme une convolution avec une PSF suivie d'un bruit et applique des filtres inverses ou regularises pour recuperer l'image d'origine.
+
 
 ## Organisation du projet
 


### PR DESCRIPTION
## Summary
- expanded each README with additional theoretical background
- described fundamental concepts for filtering, restoration and segmentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`